### PR TITLE
Resolve #9: make MLPipeline constructor accept a list of Block names

### DIFF
--- a/examples/pipelines/image/simple_cnn_classifier.py
+++ b/examples/pipelines/image/simple_cnn_classifier.py
@@ -32,10 +32,10 @@ for hyperparam in simple_cnn.get_fixed_hyperparams():
 for hyperparam in simple_cnn.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {'simple_cnn', 'convert_class_probs'}
-steps = set(simple_cnn.steps_dict.keys())
-assert expected_steps == steps
+# Check that the blocks are correct.
+expected_blocks = {'simple_cnn', 'convert_class_probs'}
+blocks = set(simple_cnn.blocks.keys())
+assert expected_blocks == blocks
 
 # Only use 1/10 of the data for quick testing.
 x_sample = X[:len(X) // 30]

--- a/examples/pipelines/image/traditional_image_pipeline.py
+++ b/examples/pipelines/image/traditional_image_pipeline.py
@@ -29,10 +29,10 @@ for hyperparam in traditional_image.get_fixed_hyperparams():
 for hyperparam in traditional_image.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {'HOG', 'rf_classifier'}
-steps = set(traditional_image.steps_dict.keys())
-assert expected_steps == steps
+# Check that the blocks are correct.
+expected_blocks = {'HOG', 'rf_classifier'}
+blocks = set(traditional_image.blocks.keys())
+assert expected_blocks == blocks
 
 # Check that we can update our pipeline's tunable hyperparameter
 # values.

--- a/examples/pipelines/tabular/random_forest_classifier.py
+++ b/examples/pipelines/tabular/random_forest_classifier.py
@@ -25,10 +25,10 @@ rf_classifier = RandomForestClassifier()
 for hyperparam in rf_classifier.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {'rf_classifier'}
-steps = set(rf_classifier.steps_dict.keys())
-assert expected_steps == steps
+# Check that the blocks are correct.
+expected_blocks = {'rf_classifier'}
+blocks = set(rf_classifier.blocks.keys())
+assert expected_blocks == blocks
 
 # Check that we can score properly.
 print("\nFitting pipeline...")

--- a/examples/pipelines/tabular/random_forest_regressor.py
+++ b/examples/pipelines/tabular/random_forest_regressor.py
@@ -26,10 +26,10 @@ rf_regressor = RandomForestRegressor()
 for hyperparam in rf_regressor.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {'rf_regressor'}
-steps = set(rf_regressor.steps_dict.keys())
-assert expected_steps == steps
+# Check that the blocks are correct.
+expected_blocks = {'rf_regressor'}
+blocks = set(rf_regressor.blocks.keys())
+assert expected_blocks == blocks
 
 # Check that we can score properly.
 print("\nFitting pipeline...")

--- a/examples/pipelines/text/lstm_text_classifier.py
+++ b/examples/pipelines/text/lstm_text_classifier.py
@@ -33,12 +33,12 @@ for hyperparam in lstm_text.get_fixed_hyperparams():
 for hyperparam in lstm_text.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {
+# Check that the blocks are correct.
+expected_blocks = {
     'tokenizer', 'sequence_padder', 'lstm_text', 'convert_class_probs'
 }
-steps = set(lstm_text.steps_dict.keys())
-assert expected_steps == steps
+blocks = set(lstm_text.blocks.keys())
+assert expected_blocks == blocks
 
 # Only use 1/30 of the data for quick testing.
 x_sample = X[:len(X) // 30]

--- a/examples/pipelines/text/traditional_text_pipeline.py
+++ b/examples/pipelines/text/traditional_text_pipeline.py
@@ -32,13 +32,13 @@ for hyperparam in traditional_text.get_fixed_hyperparams():
 for hyperparam in traditional_text.get_tunable_hyperparams():
     print(hyperparam)
 
-# Check that the steps are correct.
-expected_steps = {
+# Check that the blocks are correct.
+expected_blocks = {
     'count_vectorizer', 'to_array', 'tfidf_transformer',
     'multinomial_nb'
 }
-steps = set(traditional_text.steps_dict.keys())
-assert expected_steps == steps
+blocks = set(traditional_text.blocks.keys())
+assert expected_blocks == blocks
 
 # Check that we can score properly.
 print("\nFitting pipeline...")

--- a/mlblocks/components/pipelines/image/simple_cnn.py
+++ b/mlblocks/components/pipelines/image/simple_cnn.py
@@ -17,10 +17,10 @@ class SimpleCnnClassifier(MLPipeline):
         Dropout
         Dense
     """
+    BLOCKS = ['simple_cnn', 'convert_class_probs']
 
-    def __new__(cls, num_classes, optimizer=None, loss=None):
-        simple_cnn = MLPipeline.from_ml_json(
-            ['simple_cnn', 'convert_class_probs'])
+    def __init__(self, num_classes, optimizer=None, loss=None):
+        super(SimpleCnnClassifier, self).__init__()
 
         update_params = {
             ('simple_cnn', 'dense2_units'): num_classes,
@@ -30,22 +30,25 @@ class SimpleCnnClassifier(MLPipeline):
         }
         if optimizer is not None:
             update_params[('simple_cnn', 'optimizer')] = optimizer
+
         if loss is not None:
             update_params[('simple_cnn', 'loss')] = loss
-        simple_cnn.update_fixed_hyperparams(update_params)
 
-        return simple_cnn
+        self.update_fixed_hyperparams(update_params)
 
 
 class SimpleCnnRegressor(MLPipeline):
-    def __new__(cls, optimizer=None, loss=None):
-        simple_cnn = MLPipeline.from_ml_json(['simple_cnn'])
+
+    BLOCKS = ['simple_cnn']
+
+    def __init__(self, optimizer=None, loss=None):
+        super(SimpleCnnRegressor, self).__init__()
 
         update_params = {}
         if optimizer is not None:
             update_params[('simple_cnn', 'optimizer')] = optimizer
+
         if loss is not None:
             update_params[('simple_cnn', 'loss')] = loss
-        simple_cnn.update_fixed_hyperparams(update_params)
 
-        return simple_cnn
+        self.update_fixed_hyperparams(update_params)

--- a/mlblocks/components/pipelines/image/traditional_image.py
+++ b/mlblocks/components/pipelines/image/traditional_image.py
@@ -4,5 +4,4 @@ from mlblocks.ml_pipeline.ml_pipeline import MLPipeline
 class TraditionalImagePipeline(MLPipeline):
     """Traditional image pipeline using HOG features."""
 
-    def __new__(cls, *args, **kwargs):
-        return MLPipeline.from_ml_json(['HOG', 'random_forest_classifier'])
+    BLOCKS = ['HOG', 'random_forest_classifier']

--- a/mlblocks/components/pipelines/tabular/random_forest.py
+++ b/mlblocks/components/pipelines/tabular/random_forest.py
@@ -4,12 +4,10 @@ from mlblocks.ml_pipeline.ml_pipeline import MLPipeline
 class RandomForestClassifier(MLPipeline):
     """Random forest classifier pipeline."""
 
-    def __new__(cls, *args, **kwargs):
-        return MLPipeline.from_ml_json(['random_forest_classifier'])
+    BLOCKS = ['random_forest_classifier']
 
 
 class RandomForestRegressor(MLPipeline):
     """Random forest classifier pipeline."""
 
-    def __new__(cls, *args, **kwargs):
-        return MLPipeline.from_ml_json(['random_forest_regressor'])
+    BLOCKS = ['random_forest_regressor']

--- a/mlblocks/components/pipelines/text/lstm_text.py
+++ b/mlblocks/components/pipelines/text/lstm_text.py
@@ -8,10 +8,10 @@ class LstmTextClassifier(MLPipeline):
     http://www.developintelligence.com/blog/2017/06/practical-neural-networks-keras-classifying-yelp-reviews/
     """  # noqa
 
-    def __new__(cls, num_classes, pad_length=None, optimizer=None, loss=None):
-        lstm = MLPipeline.from_ml_json([
-            'tokenizer', 'sequence_padder', 'lstm_text', 'convert_class_probs'
-        ])
+    BLOCKS = ['tokenizer', 'sequence_padder', 'lstm_text', 'convert_class_probs']
+
+    def __init__(self, num_classes, pad_length=None, optimizer=None, loss=None):
+        super(LstmTextClassifier, self).__init__()
 
         update_params = {
             ('lstm_text', 'dense_units'): num_classes,
@@ -19,28 +19,32 @@ class LstmTextClassifier(MLPipeline):
             ('lstm_text', 'optimizer'): 'keras.optimizers.Adadelta',
             ('lstm_text', 'loss'): 'keras.losses.categorical_crossentropy'
         }
+
         if optimizer is not None:
             update_params[('lstm_text', 'optimizer')] = optimizer
+
         if loss is not None:
             update_params[('lstm_text', 'loss')] = loss
+
         if pad_length is not None:
             update_params[('text_padder', 'pad_length')] = pad_length
             update_params[('lstm_text', 'pad_length')] = pad_length
-        lstm.update_fixed_hyperparams(update_params)
 
-        return lstm
+        self.update_fixed_hyperparams(update_params)
 
 
 class LstmTextRegressor(MLPipeline):
-    def __new__(cls, optimizer=None, loss=None):
-        lstm = MLPipeline.from_ml_json(
-            ['tokenizer', 'sequence_padder', 'lstm_text'])
 
-        update_params = {}
+    BLOCKS = ['tokenizer', 'sequence_padder', 'lstm_text']
+
+    def __init__(self, optimizer=None, loss=None):
+        super(LstmTextRegressor, self).__init__()
+
+        update_params = dict()
         if optimizer is not None:
             update_params[('lstm_text', 'optimizer')] = optimizer
+
         if loss is not None:
             update_params[('lstm_text', 'loss')] = loss
-        lstm.update_fixed_hyperparams(update_params)
 
-        return lstm
+        self.update_fixed_hyperparams(update_params)

--- a/mlblocks/components/pipelines/text/traditional_text.py
+++ b/mlblocks/components/pipelines/text/traditional_text.py
@@ -3,9 +3,5 @@ from mlblocks.ml_pipeline.ml_pipeline import MLPipeline
 
 class TraditionalTextPipeline(MLPipeline):
     """Traditional text pipeline."""
-    BLOCKS = [
-        'count_vectorizer',
-        'to_array',
-        'tfidf_transformer',
-        'multinomial_nb',
-    ]
+
+    BLOCKS = ['count_vectorizer', 'to_array', 'tfidf_transformer', 'multinomial_nb']

--- a/mlblocks/components/pipelines/text/traditional_text.py
+++ b/mlblocks/components/pipelines/text/traditional_text.py
@@ -2,12 +2,10 @@ from mlblocks.ml_pipeline.ml_pipeline import MLPipeline
 
 
 class TraditionalTextPipeline(MLPipeline):
-    """
-    Traditional text pipeline.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        return MLPipeline.from_ml_json([
-            'count_vectorizer', 'to_array', 'tfidf_transformer',
-            'multinomial_nb'
-        ])
+    """Traditional text pipeline."""
+    BLOCKS = [
+        'count_vectorizer',
+        'to_array',
+        'tfidf_transformer',
+        'multinomial_nb',
+    ]

--- a/mlblocks/json_parsers/keras_json_parser.py
+++ b/mlblocks/json_parsers/keras_json_parser.py
@@ -19,7 +19,7 @@ class KerasJsonParser(MLJsonParser):
 
     def build_mlblock_model(self, fixed_hyperparameters,
                             tunable_hyperparameters):
-        # Load the class for this primitive step.
+        # Load the class for this primitive block.
         full_module_class = self.block_json['class']
         assert (full_module_class == 'keras.models.Sequential')   # ??
         sequential_class = self._get_class(full_module_class)

--- a/mlblocks/json_parsers/ml_json_parser.py
+++ b/mlblocks/json_parsers/ml_json_parser.py
@@ -96,7 +96,7 @@ class MLJsonParser(object):
 
             hyperparam = MLHyperparam(
                 hp_name, hp_type, hp_range, hp_is_cond, hp_val)
-            hyperparam.step_name = block_name
+            hyperparam.block_name = block_name
 
             tunable_hyperparams[hp_name] = hyperparam
 

--- a/mlblocks/ml_pipeline/ml_block.py
+++ b/mlblocks/ml_pipeline/ml_block.py
@@ -17,7 +17,7 @@ class MLBlock(object):
         """Initialize this MLBlock.
 
         Args:
-            name: The name of this step primitive.
+            name: The name of this block primitive.
             model: The actual model of this primitive that acts on
                 data.
             fixed_hyperparams: A dictionary mapping this primitive's

--- a/mlblocks/ml_pipeline/ml_hyperparam.py
+++ b/mlblocks/ml_pipeline/ml_hyperparam.py
@@ -21,11 +21,11 @@ _FLOAT_TYPES = (Type.FLOAT, Type.FLOAT_EXP)
 class MLHyperparam(object):
     """A Hyperparameter that the DeepMining system can act on.
 
-    Should belong to a DmStep.
+    Should belong to a MLBLock.
 
     Attributes:
         param_name: The name of this hyperparameter.
-        step_name: The name of the DmStep this hyperparameter belongs
+        block_name: The name of the MLBLock this hyperparameter belongs
             to.
         param_type: The type of this hyperparameter. See the Type object
             in this module for possible types.
@@ -56,7 +56,7 @@ class MLHyperparam(object):
                 specified.
         """
         self.param_name = param_name
-        self.step_name = None
+        self.block_name = None
 
         self.param_type = param_type
         self.param_range = param_range
@@ -89,13 +89,13 @@ class MLHyperparam(object):
         return (
             "Hyperparameter: "
             "Name: {0}, "
-            "Step Name: {1}, "
+            "Block Name: {1}, "
             "Type: {2}, "
             "Range: {3}, "
             "Value: {4}"
         ).format(
             self.param_name,
-            self.step_name,
+            self.block_name,
             self.param_type,
             self.param_range,
             self.value

--- a/mlblocks/ml_pipeline/ml_pipeline.py
+++ b/mlblocks/ml_pipeline/ml_pipeline.py
@@ -89,52 +89,6 @@ class MLPipeline(object):
 
             self.blocks[block.name] = block
 
-    # @classmethod
-    # def from_json_filepaths(cls, json_filepath_list):
-    #     """Initialize a MLPipeline with a list of paths to JSON files.
-
-    #     Args:
-    #         json_filepath_list: A list of paths to JSON files
-    #             representing the MLBlocks composing this pipeline.
-
-    #     Returns:
-    #         A MLPipeline defined by the JSON files.
-    #     """
-    #     loaded_json_metadata = []
-    #     for json_filepath in json_filepath_list:
-    #         with open(json_filepath, 'r') as f:
-    #             json_metadata = json.load(f)
-    #             loaded_json_metadata.append(json_metadata)
-
-    #     return cls(loaded_json_metadata)
-
-    # @classmethod
-    # def from_ml_json(cls, json_names):
-    #     """Initialize a MLPipeline with a list of block names.
-
-    #     These block names should correspond to the JSON file names
-    #     present in the components/primitive_jsons directory.
-
-    #     Args:
-    #         json_names: A list of primitive names corresponding to
-    #             JSON files in components/primitive_jsons.
-
-    #     Returns:
-    #         A MLPipeline defined by the JSON primitive names.
-    #     """
-    #     json_filepaths = []
-    #     for json_name in json_names:
-    #         json_filename = '{}.{}'.format(json_name, 'json')
-    #         path_to_json = os.path.join(_JSON_DIR, json_filename)
-    #         if not os.path.isfile(path_to_json):
-    #             error = ("No JSON corresponding to the specified "
-    #                      "name ({}) exists.".format(json_name))
-    #             raise ValueError(error)
-
-    #         json_filepaths.append(path_to_json)
-
-    #     return cls.from_json_filepaths(json_filepaths)
-
     def get_fixed_hyperparams(self):
         """Get all the fixed hyperparameters belonging to this pipeline.
 

--- a/mlblocks/ml_pipeline/ml_pipeline.py
+++ b/mlblocks/ml_pipeline/ml_pipeline.py
@@ -1,129 +1,183 @@
 import json
 import os
+from collections import OrderedDict, defaultdict
 
 from mlblocks.json_parsers import keras_json_parser, ml_json_parser
+from mlblocks.ml_pipeline.ml_block import MLBlock
+
+_CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+_JSON_DIR = os.path.join(_CURRENT_DIR, '../components/primitive_jsons')
 
 
 class MLPipeline(object):
     """A pipeline that the DeepMining system can operate on.
 
     Attributes:
-        steps_dict: A dictionary mapping this pipeline's step names to
-            DMSteps.
+        blocks: A dictionary mapping this pipeline's block names to
+                the actual MLBlock objects.
+        BLOCKS: A list containing the blocks to load. Used in Subclasses.
     """
 
-    def __init__(self, steps, dataflow=None):
-        """Initialize a DmPipeline with a list of corresponding DmSteps.
-
-        Args:
-            steps: A list of DmSteps composing this pipeline.
-        """
-        # Contains the actual primitives.
-        self.steps_dict = {
-            k: v
-            for (k, v) in [(step.name, step) for step in steps]
-        }
-
-        # For now, just use a list to order the steps.
-        self.dataflow = dataflow if dataflow is not None else [
-            step.name for step in steps
-        ]
+    BLOCKS = None
 
     @classmethod
     def _get_parser(cls, json_block_metadata):
+        # TODO: Make this a MLBlock method
         # TODO: Implement better logic for deciding what parser to
         # use. Maybe some sort of config mapping parser to modules?
+        # IDEA: organize the primitives by libraries, and decide
+        # which parser to use depending on the JSON path
         parser = ml_json_parser.MLJsonParser(json_block_metadata)
-        full_module_class = json_block_metadata['class']
 
         # For now, hardcode this logic for Keras.
+        full_module_class = json_block_metadata['class']
         if full_module_class.startswith('keras.models.Sequential'):
             parser = keras_json_parser.KerasJsonParser(json_block_metadata)
 
         return parser
 
     @classmethod
-    def from_json_metadata(cls, json_metadata):
-        """Initialize a DmPipeline with a list of dicts defining DmSteps.
+    def get_block_path(cls, block_name):
+        """Locate the JSON file of the given primitive."""
 
-        Args:
-            json_metadata: A list of dicts representing the
-                DmSteps composing this pipeline.
+        if os.path.isfile(block_name):
+            return block_name
 
-        Returns:
-            A DmPipeline defined by the provided dicts.
-        """
-        block_steps = []
-        for json_md in json_metadata:
-            parser = cls._get_parser(json_md)
-            block_steps.append(parser.build_mlblock())
+        json_filename = '{}.{}'.format(block_name, 'json')
+        block_path = os.path.join(_JSON_DIR, json_filename)
 
-        return cls(block_steps)
+        if not os.path.isfile(block_path):
+            error = ("No JSON corresponding to the specified "
+                     "name ({}) exists.".format(block_name))
+            raise ValueError(error)
 
-    @classmethod
-    def from_json_filepaths(cls, json_filepath_list):
-        """Initialize a DmPipeline with a list of paths to JSON files.
-
-        Args:
-            json_filepath_list: A list of paths to JSON files
-                representing the DmSteps composing this pipeline.
-
-        Returns:
-            A DmPipeline defined by the JSON files.
-        """
-        loaded_json_metadata = []
-        for json_filepath in json_filepath_list:
-            with open(json_filepath, 'r') as f:
-                json_metadata = json.load(f)
-                loaded_json_metadata.append(json_metadata)
-
-        return cls.from_json_metadata(loaded_json_metadata)
+        return block_path
 
     @classmethod
-    def from_ml_json(cls, json_names):
-        """Initialize a DmPipeline with a list of step names.
+    def load_block(cls, block):
+        """Build block from either a Block name or a config dict.
 
-        These step names should correspond to the JSON file names
-        present in the components/primitive_jsons directory.
+        If a string is given, it is used to locate and load the corresponding
+        JSON file, and then loaded.
+        """
+        if isinstance(block, str):
+            block_path = cls.get_block_path(block)
+            with open(block_path, 'r') as f:
+                block = json.load(f)
+
+        parser = cls._get_parser(block)
+        return parser.build_mlblock()
+
+    def __init__(self, blocks=None):
+        """Initialize a MLPipeline with a list of corresponding MLBlocks.
 
         Args:
-            json_names: A list of primitive names corresponding to
-                JSON files in components/primitive_jsons.
+            blocks: A list of MLBlocks composing this pipeline. MLBlocks
+                    can be either MLBlock instances or primitive names to
+                    load from the configuration JSON files.
+        """
+
+        blocks = blocks or self.BLOCKS
+
+        if not blocks:
+            raise ValueError("At least one block is needed")
+
+        self.blocks = OrderedDict()
+        for block in blocks:
+            if not isinstance(block, MLBlock):
+                block = self.load_block(block)
+
+            self.blocks[block.name] = block
+
+    # @classmethod
+    # def from_json_filepaths(cls, json_filepath_list):
+    #     """Initialize a MLPipeline with a list of paths to JSON files.
+
+    #     Args:
+    #         json_filepath_list: A list of paths to JSON files
+    #             representing the MLBlocks composing this pipeline.
+
+    #     Returns:
+    #         A MLPipeline defined by the JSON files.
+    #     """
+    #     loaded_json_metadata = []
+    #     for json_filepath in json_filepath_list:
+    #         with open(json_filepath, 'r') as f:
+    #             json_metadata = json.load(f)
+    #             loaded_json_metadata.append(json_metadata)
+
+    #     return cls(loaded_json_metadata)
+
+    # @classmethod
+    # def from_ml_json(cls, json_names):
+    #     """Initialize a MLPipeline with a list of block names.
+
+    #     These block names should correspond to the JSON file names
+    #     present in the components/primitive_jsons directory.
+
+    #     Args:
+    #         json_names: A list of primitive names corresponding to
+    #             JSON files in components/primitive_jsons.
+
+    #     Returns:
+    #         A MLPipeline defined by the JSON primitive names.
+    #     """
+    #     json_filepaths = []
+    #     for json_name in json_names:
+    #         json_filename = '{}.{}'.format(json_name, 'json')
+    #         path_to_json = os.path.join(_JSON_DIR, json_filename)
+    #         if not os.path.isfile(path_to_json):
+    #             error = ("No JSON corresponding to the specified "
+    #                      "name ({}) exists.".format(json_name))
+    #             raise ValueError(error)
+
+    #         json_filepaths.append(path_to_json)
+
+    #     return cls.from_json_filepaths(json_filepaths)
+
+    def get_fixed_hyperparams(self):
+        """Get all the fixed hyperparameters belonging to this pipeline.
 
         Returns:
-            A DmPipeline defined by the JSON primitive names.
+            A dict mapping (block name, fixed hyperparam name) pairs to
+            fixed hyperparam values.
         """
-        current_dir = os.path.dirname(os.path.realpath(__file__))
-        json_dir = os.path.join(current_dir, '../components/primitive_jsons')
+        fixed_hyperparams = {}
+        for block in self.blocks.values():
+            for hp_name in block.fixed_hyperparams:
+                hyperparam = block.fixed_hyperparams[hp_name]
+                fixed_hyperparams[(block.name, hp_name)] = hyperparam
 
-        json_filepaths = []
-        for json_name in json_names:
-            json_filename = '{}.{}'.format(json_name, 'json')
-            path_to_json = os.path.join(json_dir, json_filename)
-            if not os.path.isfile(path_to_json):
-                error = ("No JSON corresponding to the specified "
-                         "name ({}) exists.".format(json_name))
-                raise ValueError(error)
-
-            json_filepaths.append(path_to_json)
-
-        return cls.from_json_filepaths(json_filepaths)
+        return fixed_hyperparams
 
     def update_fixed_hyperparams(self, fixed_hyperparams):
         """Update the specified fixed hyperparameters of this pipeline.
 
         Args:
             fixed_hyperparams: A dict mapping
-                (step name, fixed hyperparam name) pairs to their
+                (block name, fixed hyperparam name) pairs to their
                 corresponding values.
         """
-        for step_name, hyperparam_name in fixed_hyperparams:
-            step = self.steps_dict[step_name]
-            hyperparam = fixed_hyperparams[(step_name, hyperparam_name)]
-            step.fixed_hyperparams[hyperparam_name] = hyperparam
+        for block_name, hyperparam_name in fixed_hyperparams:
+            block = self.blocks[block_name]
+            hyperparam = fixed_hyperparams[(block_name, hyperparam_name)]
+            block.fixed_hyperparams[hyperparam_name] = hyperparam
 
             # Update the hyperparams in the actual model as well.
-            step.update_model(step.fixed_hyperparams, step.tunable_hyperparams)
+            block.update_model(block.fixed_hyperparams, block.tunable_hyperparams)
+
+    def get_tunable_hyperparams(self):
+        """Get all tunable hyperparameters belonging to this pipeline.
+
+        Returns:
+            A list of tunable hyperparameters belonging to this
+            pipeline.
+        """
+        tunable_hyperparams = []
+        for block in self.blocks.values():
+            tunable_hyperparams += list(block.tunable_hyperparams.values())
+
+        return tunable_hyperparams
 
     def update_tunable_hyperparams(self, tunable_hyperparams):
         """Update the specified tunable hyperparameters of this pipeline.
@@ -134,54 +188,26 @@ class MLPipeline(object):
             tunable_hyperparams: A list of MLHyperparams to update.
         """
         for hyperparam in tunable_hyperparams:
-            step_name = hyperparam.step_name
-            step = self.steps_dict[step_name]
-            step.tunable_hyperparams[hyperparam.param_name] = hyperparam
+            block_name = hyperparam.block_name
+            block = self.blocks[block_name]
+            block.tunable_hyperparams[hyperparam.param_name] = hyperparam
             # Update the hyperparams in the actual model as well.
-            step.update_model(step.fixed_hyperparams, step.tunable_hyperparams)
-
-    def get_fixed_hyperparams(self):
-        """Get all the fixed hyperparameters belonging to this pipeline.
-
-        Returns:
-            A dict mapping (step name, fixed hyperparam name) pairs to
-            fixed hyperparam values.
-        """
-        fixed_hyperparams = {}
-        for step in self.steps_dict.values():
-            for hp_name in step.fixed_hyperparams:
-                hyperparam = step.fixed_hyperparams[hp_name]
-                fixed_hyperparams[(step.name, hp_name)] = hyperparam
-
-        return fixed_hyperparams
-
-    def get_tunable_hyperparams(self):
-        """Get all tunable hyperparameters belonging to this pipeline.
-
-        Returns:
-            A list of tunable hyperparameters belonging to this
-            pipeline.
-        """
-        tunable_hyperparams = []
-        for step in self.steps_dict.values():
-            tunable_hyperparams += list(step.tunable_hyperparams.values())
-
-        return tunable_hyperparams
+            block.update_model(block.fixed_hyperparams, block.tunable_hyperparams)
 
     def set_from_hyperparam_dict(self, hyperparam_dict):
         """Set the hyperparameters of this pipeline from a dict.
 
         This dict maps as follows:
-            (step name, hyperparam name): value
+            (block name, hyperparam name): value
 
         Args:
-            hyperparam_dict: A dict mapping (step name, hyperparam name)
+            hyperparam_dict: A dict mapping (block name, hyperparam name)
                 tuples to hyperparam values.
         """
         all_tunable_hyperparams = self.get_tunable_hyperparams()
         for hp in all_tunable_hyperparams:
-            if (hp.step_name, hp.param_name) in hyperparam_dict:
-                hp.value = hyperparam_dict[(hp.step_name, hp.param_name)]
+            if (hp.block_name, hp.param_name) in hyperparam_dict:
+                hp.value = hyperparam_dict[(hp.block_name, hp.param_name)]
 
         self.update_tunable_hyperparams(all_tunable_hyperparams)
 
@@ -190,31 +216,30 @@ class MLPipeline(object):
 
         Args:
             x: Training data. Must fulfill input requirements of the
-                first step of the pipeline.
+                first block of the pipeline.
             y: Training targets. Must fulfill label requirements for
-                all steps of the pipeline.
+                all blocks of the pipeline.
             fit_params: Any params to pass into fit.
-                In the form {(step name, param name): param value}
+                In the form {(block name, param name): param value}
         """
         if fit_params is None:
             fit_params = {}
 
-        param_dict = {step_name: {} for step_name in self.dataflow}
+        param_dict = defaultdict(dict)
         for key, value in fit_params.items():
             name, param = key
             param_dict[name][param] = fit_params[key]
 
         # Initially our transformed data is simply our input data.
         transformed_data = x
-        for step_name in self.dataflow:
-            step = self.steps_dict[step_name]
+        for block_name, block in self.blocks.items():
             try:
-                step.fit(transformed_data, y, **param_dict[step_name])
+                block.fit(transformed_data, y, **param_dict[block_name])
             except TypeError:
                 # Some components only fit on an X.
-                step.fit(transformed_data, **param_dict[step_name])
+                block.fit(transformed_data, **param_dict[block_name])
 
-            transformed_data = step.produce(transformed_data)
+            transformed_data = block.produce(transformed_data)
 
     def predict(self, x):
         """Make predictions with this pipeline on the specified input data.
@@ -223,26 +248,25 @@ class MLPipeline(object):
 
         Args:
             x: Input data. Must fulfill input requirements of the first
-                step of the pipeline.
+                block of the pipeline.
 
         Returns:
             The predicted values.
         """
         transformed_data = x
-        for step_name in self.dataflow:
-            step = self.steps_dict[step_name]
-            transformed_data = step.produce(transformed_data)
+        for block in self.blocks.values():
+            transformed_data = block.produce(transformed_data)
 
         # The last value stored in transformed_data is our final output value.
         return transformed_data
 
-    def __str__(self):
-        return str(self.to_dict())
-
     def to_dict(self):
         all_tunable_hyperparams = self.get_tunable_hyperparams()
         return {
-            '{0}__{1}'.format(hyperparam.step_name, hyperparam.param_name):
+            '{0}__{1}'.format(hyperparam.block_name, hyperparam.param_name):
             hyperparam.value
             for hyperparam in all_tunable_hyperparams
         }
+
+    def __str__(self):
+        return str(self.to_dict())


### PR DESCRIPTION
Make MLPipeline accept block names as input.

Now, all these options are valid:

```
>>> from mlblocks.ml_pipeline.ml_pipeline import MLPipeline

# Passing a list of block names
>>> pipeline = MLPipeline(['random_forest_classifier'])

# Passing a list of json paths
>>> pipeline = MLPipeline(['mlblocks/components/primitive_jsons/random_forest_classifier.json'])

# Passing a list of dictionaries
>>> primitive_dict = {
...     "name": "to_array",
...     "class": "mlblocks.components.functions.tabular.ml_utils_block.MLUtilsBlock",
...     "fit": "",
...     "produce": "to_array",
...     "fixed_hyperparameters": {},
...     "tunable_hyperparameters": {},
...     "root_hyperparameters": [],
...     "conditional_hyperparameters": {}
... }
>>> pipeline = MLPipeline([primitive_dict])

# Combining any of the previous options
>>> pipeline = MLPipeline([primitive_dict, 'random_forest_classifier'])

# Creating a subclass with a fixed set of blocks
>>> class TestPipeline(MLPipeline):
...     BLOCKS = ['HOG', 'random_forest_classifier']
... 
>>> pipeline = TestPipeline()
```