### PR TITLE
NetworkX primitives improvements

### DIFF
--- a/mlblocks/primitives/custom/nx_graph_featurization.py
+++ b/mlblocks/primitives/custom/nx_graph_featurization.py
@@ -22,6 +22,12 @@ class GraphFeaturization(object):
         features['cc_' + node_column] = apply(nx.closeness_centrality)
         features['bc_' + node_column] = apply(nx.betweenness_centrality)
         features['clustering_' + node_column] = apply(nx.clustering)
+        features['ec_' + node_column] = apply(nx.eigenvector_centrality)
+        features['kc_' + node_column] = apply(nx.katz_centrality)
+        features['comc_' + node_column] = apply(nx.communicability_betweenness_centrality)
+        features['lc_' + node_column] = apply(nx.load_centrality)
+        features['nr_' + node_column] = apply(nx.algorithms.bipartite.node_redundancy)
+        features['lac_' + node_column] = apply(nx.algorithms.bipartite.cluster.latapy_clustering)
 
         merged = X.merge(features, left_on=node_column, right_index=True, how='left')
 

--- a/mlblocks/primitives/custom/nx_link_prediction.py
+++ b/mlblocks/primitives/custom/nx_link_prediction.py
@@ -1,5 +1,9 @@
+import logging
+
 import networkx as nx
 import numpy as np
+
+LOGGER = logging.getLogger(__name__)
 
 
 class LinkPrediction(object):
@@ -13,8 +17,12 @@ class LinkPrediction(object):
 
         for i, graph in enumerate(graphs):
             def apply(function):
-                values = function(graph, pairs)
-                return np.array(list(values))[:, 2]
+                try:
+                    values = function(graph, pairs)
+                    return np.array(list(values))[:, 2]
+                except ZeroDivisionError:
+                    LOGGER.warn("ZeroDivisionError captured running %s", function)
+                    return np.zeros(len(pairs))
 
             i = str(i)
             X['jc_' + i] = apply(nx.jaccard_coefficient)


### PR DESCRIPTION
* Add some more NetworkX methods to `nx_graph_featurization` primitive
* Catch and safely ignore a `ZeroDivisionError` that shows up when `adamic_adar_index` is called and there is some value where `G.degree == 1`