### PR TITLE
Filter conditionals from tunable hyperparameters

### DIFF
--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -110,6 +110,33 @@ class MLBlock():
 
         return init_params, fit_params, produce_params
 
+    @staticmethod
+    def _filter_conditional(conditional, init_params):
+        condition = conditional['condition']
+        if condition not in init_params:
+            return conditional
+
+        condition_value = init_params[condition]
+        values = conditional['values']
+        conditioned = values.get(condition_value) or values.get('*')
+        if conditioned:
+            return conditioned
+
+    @classmethod
+    def _get_tunable(cls, hyperparameters, init_params):
+        tunable = dict()
+        for name, param in hyperparameters.get('tunable', dict()).items():
+            if name not in init_params:
+                if param['type'] == 'conditional':
+                    param = cls._filter_conditional(param, init_params)
+                    if param is not None:
+                        tunable[name] = param
+
+                else:
+                    tunable[name] = param
+
+        return tunable
+
     def __init__(self, name, **kwargs):
 
         self.name = name
@@ -136,13 +163,7 @@ class MLBlock():
         self._fit_params = fit_params
         self._produce_params = produce_params
 
-        tunable = hyperparameters.get('tunable', dict())
-        self._tunable = {
-            name: param
-            for name, param in tunable.items()
-            if name not in init_params
-            # TODO: filter conditionals
-        }
+        self._tunable = self._get_tunable(hyperparameters, init_params)
 
         default = {
             name: param['default']

--- a/tests/test_mlblock.py
+++ b/tests/test_mlblock.py
@@ -23,6 +23,225 @@ class TestMLBlock(TestCase):
     def test__extract_params(self):
         pass
 
+    def test__get_tunable_no_conditionals(self):
+        """If there are no conditionals, tunables are returned unmodified."""
+
+        # setup
+        init_params = {
+            'an_init_param': 'a_value'
+        }
+        hyperparameters = {
+            'tunable': {
+                'this_is_not_conditional': {
+                    'type': 'int',
+                    'default': 1
+                }
+            }
+        }
+
+        # run
+        tunable = MLBlock._get_tunable(hyperparameters, init_params)
+
+        # assert
+        expected = {
+            'this_is_not_conditional': {
+                'type': 'int',
+                'default': 1
+            }
+        }
+        assert tunable == expected
+
+    def test__get_tunable_no_condition(self):
+        """If there is a conditiona but no condition, conditional is returned unmodified."""
+
+        # setup
+        init_params = {
+            'an_init_param': 'a_value'
+        }
+        hyperparameters = {
+            'tunable': {
+                'this_is_not_conditional': {
+                    'type': 'int',
+                    'default': 1
+                },
+                'this_is_conditional': {
+                    'type': 'conditional',
+                    'condition': 'a_condition',
+                    'default': 1,
+                    'values': {
+                        1: {
+                            'type': 'int',
+                            'default': 0
+                        },
+                        '*': {
+                            'type': 'str',
+                            'default': 'whatever'
+                        }
+                    }
+                }
+            }
+        }
+
+        # run
+        tunable = MLBlock._get_tunable(hyperparameters, init_params)
+
+        # assert
+        expected = {
+            'this_is_not_conditional': {
+                'type': 'int',
+                'default': 1
+            },
+            'this_is_conditional': {
+                'type': 'conditional',
+                'condition': 'a_condition',
+                'default': 1,
+                'values': {
+                    1: {
+                        'type': 'int',
+                        'default': 0
+                    },
+                    '*': {
+                        'type': 'str',
+                        'default': 'whatever'
+                    }
+                }
+            }
+        }
+        assert tunable == expected
+
+    def test__get_tunable_condition_match(self):
+        """If there is a conditional and it matches, only that part is returned."""
+
+        # setup
+        init_params = {
+            'a_condition': 'match'
+        }
+        hyperparameters = {
+            'tunable': {
+                'this_is_not_conditional': {
+                    'type': 'int',
+                    'default': 1
+                },
+                'this_is_conditional': {
+                    'type': 'conditional',
+                    'condition': 'a_condition',
+                    'default': 1,
+                    'values': {
+                        'match': {
+                            'type': 'int',
+                            'default': 0
+                        },
+                        '*': {
+                            'type': 'str',
+                            'default': 'whatever'
+                        }
+                    }
+                }
+            }
+        }
+
+        # run
+        tunable = MLBlock._get_tunable(hyperparameters, init_params)
+
+        # assert
+        expected = {
+            'this_is_not_conditional': {
+                'type': 'int',
+                'default': 1
+            },
+            'this_is_conditional': {
+                'type': 'int',
+                'default': 0
+            }
+        }
+        assert tunable == expected
+
+    def test__get_tunable_condition_wildcard_match(self):
+        """If there is a conditional and it matches the wildcard, only that part is returned."""
+
+        # setup
+        init_params = {
+            'a_condition': 'no_match'
+        }
+        hyperparameters = {
+            'tunable': {
+                'this_is_not_conditional': {
+                    'type': 'int',
+                    'default': 1
+                },
+                'this_is_conditional': {
+                    'type': 'conditional',
+                    'condition': 'a_condition',
+                    'default': 1,
+                    'values': {
+                        'match': {
+                            'type': 'int',
+                            'default': 0
+                        },
+                        '*': {
+                            'type': 'str',
+                            'default': 'whatever'
+                        }
+                    }
+                }
+            }
+        }
+
+        # run
+        tunable = MLBlock._get_tunable(hyperparameters, init_params)
+
+        # assert
+        expected = {
+            'this_is_not_conditional': {
+                'type': 'int',
+                'default': 1
+            },
+            'this_is_conditional': {
+                'type': 'str',
+                'default': 'whatever'
+            }
+        }
+        assert tunable == expected
+
+    def test__get_tunable_condition_no_match(self):
+        """If there is a conditional without match or wildcard, it is not returned."""
+
+        # setup
+        init_params = {
+            'a_condition': 'no_match'
+        }
+        hyperparameters = {
+            'tunable': {
+                'this_is_not_conditional': {
+                    'type': 'int',
+                    'default': 1
+                },
+                'this_is_conditional': {
+                    'type': 'conditional',
+                    'condition': 'a_condition',
+                    'default': 1,
+                    'values': {
+                        'match': {
+                            'type': 'int',
+                            'default': 0
+                        }
+                    }
+                }
+            }
+        }
+
+        # run
+        tunable = MLBlock._get_tunable(hyperparameters, init_params)
+
+        # assert
+        expected = {
+            'this_is_not_conditional': {
+                'type': 'int',
+                'default': 1
+            }
+        }
+        assert tunable == expected
+
     @patch('mlblocks.mlblock.MLBlock.set_hyperparameters')
     @patch('mlblocks.mlblock.import_object')
     @patch('mlblocks.mlblock.load_primitive')


### PR DESCRIPTION
Resolve #55 

Conditional hyperparameters are now checked when the MLBlock is created, so any invalid values are removed from the tunables list.
If the condition for the tunable has not been set as an init_param, it is maintained there for later filtering.