### PR TITLE
Issue 58 intermediate outputs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -172,24 +172,26 @@ The process of releasing a new version involves several steps combining both ``g
 
 1. Merge what is in ``master`` branch into ``stable`` branch.
 2. Update the version in ``setup.cfg``, ``mlblocks/__init__.py`` and ``HISTORY.md`` files.
-3. Create a new TAG pointing at the correspoding commit in ``stable`` branch.
+3. Create a new git tag pointing at the corresponding commit in ``stable`` branch.
 4. Merge the new commit from ``stable`` into ``master``.
-5. Update the version in ``setup.cfg`` and ``mlblocks/__init__.py`` to open the next
-   development interation.
+5. Update the version in ``setup.cfg`` and ``mlblocks/__init__.py``
+   to open the next development iteration.
 
-**Note:** Before starting the process, make sure that ``HISTORY.md`` has a section titled
-**Unreleased** with the list of changes that will be included in the new version, and that
-these changes are committed and available in ``master`` branch.
-Normally this is just a list of the Pull Requests that have been merged since the latest version.
+.. note:: Before starting the process, make sure that ``HISTORY.md`` has been updated with a new
+          entry that explains the changes that will be included in the new version.
+          Normally this is just a list of the Pull Requests that have been merged to master
+          since the last release.
 
-Once this is done, just run the following commands::
+Once this is done, run of the following commands:
 
-    git checkout stable
-    git merge --no-ff master    # This creates a merge commit
-    bumpversion release   # This creates a new commit and a TAG
-    git push --tags origin stable
+1. If you are releasing a patch version::
+
     make release
-    git checkout master
-    git merge stable
-    bumpversion --no-tag patch
-    git push
+
+2. If you are releasing a minor version::
+
+    make release-minor
+
+3. If you are releasing a major version::
+
+    make release-major

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ fix-lint: ## fix lint issues using autoflake, autopep8, and isort
 	autopep8 --in-place --recursive --aggressive tests
 	isort --apply --atomic --recursive tests
 
+.PHONY: lint-docs
+lint-docs: ## check docs formatting with doc8 and pydocstyle
+	doc8 mlblocks/
+	pydocstyle mlblocks/
+
 
 # TEST TARGETS
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ coverage: ## check code coverage quickly with the default Python
 .PHONY: docs
 docs: clean-docs ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
-	touch docs/_build/html/.nojekyll
 
 .PHONY: view-docs
 view-docs: docs ## view docs in browser

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,1 @@
-.. include:: ../HISTORY.md
+.. mdinclude:: ../HISTORY.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,18 +18,9 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 
-import os
-import sys
-
 import sphinx_rtd_theme # For read the docs theme
-from recommonmark.parser import CommonMarkParser
-# from recommonmark.transform import AutoStructify
-
-# sys.path.insert(0, os.path.abspath('..'))
 
 import mlblocks
-# 
-# mlblocks.add_primitives_path('../mlblocks_primitives')
 
 # -- General configuration ---------------------------------------------
 
@@ -40,8 +31,11 @@ import mlblocks
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.napoleon',
+    'm2r',
+    'sphinx.ext.autodoc',
     'sphinx.ext.githubpages',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
     'sphinx.ext.graphviz',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
@@ -56,9 +50,9 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 source_suffix = ['.rst', '.md', '.ipynb']
 
-source_parsers = {
-    '.md': CommonMarkParser,
-}
+# source_parsers = {
+#     '.md': CommonMarkParser,
+# }
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,12 @@ extensions = [
     'sphinx.ext.graphviz',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
+    'autodocsumm',
 ]
+
+autodoc_default_options = {
+    'autosummary': True,
+}
 
 ipython_execlines = ["import pandas as pd", "pd.set_option('display.width', 1000000)"]
 
@@ -49,10 +54,6 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 source_suffix = ['.rst', '.md', '.ipynb']
-
-# source_parsers = {
-#     '.md': CommonMarkParser,
-# }
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -24,7 +24,7 @@ them to the `MLPipeline class`_:
 
     from mlblocks import MLPipeline
     primitives = [
-        'mlprimitives.feature_extraction.StringVectorizer',
+        'mlprimitives.custom.feature_extraction.StringVectorizer',
         'sklearn.ensemble.RandomForestClassifier',
     ]
     pipeline = MLPipeline(primitives)

--- a/docs/pipeline_examples/graph.rst
+++ b/docs/pipeline_examples/graph.rst
@@ -39,7 +39,7 @@ additional information not found inside `X`.
 
     primitives = [
         'networkx.link_prediction_feature_extraction',
-        'mlprimitives.feature_extraction.CategoricalEncoder',
+        'mlprimitives.custom.feature_extraction.CategoricalEncoder',
         'sklearn.preprocessing.StandardScaler',
         'xgboost.XGBClassifier'
     ]
@@ -69,6 +69,6 @@ additional information not found inside `X`.
 
 
 .. _NetworkX Link Prediction: https://networkx.github.io/documentation/networkx-1.10/reference/algorithms.link_prediction.html
-.. _CategoricalEncoder from MLPrimitives: https://github.com/HDI-Project/MLPrimitives/blob/master/mlblocks_primitives/mlprimitives.feature_extraction.CategoricalEncoder.json
+.. _CategoricalEncoder from MLPrimitives: https://github.com/HDI-Project/MLPrimitives/blob/master/mlblocks_primitives/mlprimitives.custom.feature_extraction.CategoricalEncoder.json
 .. _StandardScaler from scikit-learn: http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html
 .. _XGBClassifier: https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn

--- a/docs/pipeline_examples/text.rst
+++ b/docs/pipeline_examples/text.rst
@@ -40,31 +40,31 @@ for later ones.
 
     # set up the pipeline
     primitives = [
-        "mlprimitives.counters.UniqueCounter",
-        "mlprimitives.text.TextCleaner",
-        "mlprimitives.counters.VocabularyCounter",
+        "mlprimitives.custom.counters.UniqueCounter",
+        "mlprimitives.custom.text.TextCleaner",
+        "mlprimitives.custom.counters.VocabularyCounter",
         "keras.preprocessing.text.Tokenizer",
         "keras.preprocessing.sequence.pad_sequences",
         "keras.Sequential.LSTMTextClassifier"
     ]
     input_names = {
-        "mlprimitives.counters.UniqueCounter#1": {
+        "mlprimitives.custom.counters.UniqueCounter#1": {
             "X": "y"
         }
     }
     output_names = {
-        "mlprimitives.counters.UniqueCounter#1": {
+        "mlprimitives.custom.counters.UniqueCounter#1": {
             "counts": "classes"
         },
-        "mlprimitives.counters.VocabularyCounter#1": {
+        "mlprimitives.custom.counters.VocabularyCounter#1": {
             "counts": "vocabulary_size"
         }
     }
     init_params = {
-        "mlprimitives.counters.VocabularyCounter#1": {
+        "mlprimitives.custom.counters.VocabularyCounter#1": {
             "add": 1
         },
-        "mlprimitives.text.TextCleaner#1": {
+        "mlprimitives.custom.text.TextCleaner#1": {
             "language": "en"
         },
         "keras.preprocessing.sequence.pad_sequences#1": {
@@ -116,12 +116,12 @@ to encode all the string features, and go directly into the
     nltk.download('stopwords')
 
     primitives = [
-        'mlprimitives.text.TextCleaner',
-        'mlprimitives.feature_extraction.StringVectorizer',
+        'mlprimitives.custom.text.TextCleaner',
+        'mlprimitives.custom.feature_extraction.StringVectorizer',
         'sklearn.ensemble.RandomForestClassifier',
     ]
     init_params = {
-        'mlprimitives.text.TextCleaner': {
+        'mlprimitives.custom.text.TextCleaner': {
             'column': 'text',
             'language': 'nl'
         },

--- a/mlblocks/datasets.py
+++ b/mlblocks/datasets.py
@@ -100,6 +100,7 @@ class Dataset():
         **kwargs: Any additional keyword argument passed on initialization will be made
             available as instance attributes.
     """
+
     def __init__(self, description, data, target, score, shuffle=True, stratify=False, **kwargs):
 
         self.name = description.splitlines()[0]
@@ -115,10 +116,10 @@ class Dataset():
         self.__dict__.update(kwargs)
 
     def score(self, *args, **kwargs):
-        """Scoring function for this dataset.
+        r"""Scoring function for this dataset.
 
         Args:
-            \\*args, \\*\\*kwargs: Any given arguments and keyword arguments will be
+            \*args, \*\*kwargs: Any given arguments and keyword arguments will be
             directly passed to the given scoring function.
 
         Returns:
@@ -315,7 +316,6 @@ def load_dic28():
     There exist 52,652 words (vertices in a network) having 2 up to 8 characters
     in the dictionary. The obtained network has 89038 edges.
     """
-
     dataset_path = _load('dic28')
 
     X = _load_csv(dataset_path, 'data')
@@ -344,7 +344,6 @@ def load_nomination():
     Data consists of one graph whose nodes contain two attributes, attr1 and attr2.
     Associated with each node is a label that has to be learned and predicted.
     """
-
     dataset_path = _load('nomination')
 
     X = _load_csv(dataset_path, 'data')
@@ -363,7 +362,6 @@ def load_amazon():
     co-purchased with product j, the graph contains an undirected edge from i to j.
     Each product category provided by Amazon defines each ground-truth community.
     """
-
     dataset_path = _load('amazon')
 
     X = _load_csv(dataset_path, 'data')
@@ -383,7 +381,6 @@ def load_jester():
     source: "University of California Berkeley, CA"
     sourceURI: "http://eigentaste.berkeley.edu/dataset/"
     """
-
     dataset_path = _load('jester')
 
     X = _load_csv(dataset_path, 'data')
@@ -393,7 +390,7 @@ def load_jester():
 
 
 def load_wikiqa():
-    """A Challenge Dataset for Open-Domain Question Answering.
+    """Challenge Dataset for Open-Domain Question Answering.
 
     WikiQA dataset is a publicly available set of question and sentence (QS) pairs,
     collected and annotated for research on open-domain question answering.
@@ -401,7 +398,6 @@ def load_wikiqa():
     source: "Microsoft"
     sourceURI: "https://www.microsoft.com/en-us/research/publication/wikiqa-a-challenge-dataset-for-open-domain-question-answering/#"
     """  # noqa
-
     dataset_path = _load('wikiqa')
 
     data = _load_csv(dataset_path, 'data', set_index=True)

--- a/mlblocks/datasets.py
+++ b/mlblocks/datasets.py
@@ -141,7 +141,7 @@ class Dataset():
         else:
             return data[index]
 
-    def get_splits(self, n_splits=1):
+    def get_splits(self, n_splits=1, random_state=0):
         """Return splits of this dataset ready for Cross Validation.
 
         If n_splits is 1, a tuple containing the X for train and test
@@ -166,12 +166,13 @@ class Dataset():
                 self.data,
                 self.target,
                 shuffle=self._shuffle,
-                stratify=stratify
+                stratify=stratify,
+                random_state=random_state
             )
 
         else:
             cv_class = StratifiedKFold if self._stratify else KFold
-            cv = cv_class(n_splits=n_splits, shuffle=self._shuffle)
+            cv = cv_class(n_splits=n_splits, shuffle=self._shuffle, random_state=random_state)
 
             splits = list()
             for train, test in cv.split(self.data, self.target):

--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -25,32 +25,34 @@ class MLBlock():
     as wrapping them and providing a common interface to run them.
 
     Attributes:
-        name (str): Name given to this MLBlock.
-        primitive (object): the actual function or instance which this MLBlock
-                            wraps.
-        fit_args (dict): specification of the arguments expected by the `fit`
-                         method.
-        fit_method (str): name of the primitive method to call on `fit`.
-                          `None` if the primitive is a function.
-        produce_args (dict): specification of the arguments expected by the
-                             `predict` method.
-        produce_output (dict): specification of the outputs of the `produce`
-                               method.
-        produce_method (str): name of the primitive method to call on
-                              `produce`. `None` if the primitive is a function.
+        name (str):
+            Name given to this MLBlock.
+        primitive (object):
+            the actual function or instance which this MLBlock wraps.
+        fit_args (dict):
+            specification of the arguments expected by the `fit` method.
+        fit_method (str):
+            name of the primitive method to call on `fit`. `None` if the primitive is a function.
+        produce_args (dict):
+            specification of the arguments expected by the `predict` method.
+        produce_output (dict):
+            specification of the outputs of the `produce` method.
+        produce_method (str):
+            name of the primitive method to call on `produce`. `None` if the primitive is a
+            function.
 
     Args:
-        name (str): Name given to this MLBlock.
-        **kwargs: Any additional arguments that will be used as
-                  hyperparameters or passed to the `fit` or `produce`
-                  methods.
+        name (str):
+            Name given to this MLBlock.
+        **kwargs:
+            Any additional arguments that will be used as hyperparameters or passed to the
+            `fit` or `produce` methods.
 
     Raises:
-        TypeError: A `TypeError` is raised if a required argument is not
-                   found within the `kwargs` or if an unexpected
-                   argument has been given.
-    """
-    # pylint: disable=too-many-instance-attributes
+        TypeError:
+            A `TypeError` is raised if a required argument is not found within the `kwargs`
+            or if an unexpected argument has been given.
+    """  # pylint: disable=too-many-instance-attributes
 
     def _extract_params(self, kwargs, hyperparameters):
         """Extract init, fit and produce params from kwargs.
@@ -63,16 +65,16 @@ class MLBlock():
         have been given and that nothing unexpected exists in the input.
 
         Args:
-            kwargs (dict): dict containing the Keyword arguments that have
-                           been passed to the `__init__` method upon
-                           initialization.
-            hyperparameters (dict): hyperparameters dictionary, as found in
-                                    the JSON annotation.
+            kwargs (dict):
+                dict containing the Keyword arguments that have been passed to the `__init__`
+                method upon initialization.
+            hyperparameters (dict):
+                hyperparameters dictionary, as found in the JSON annotation.
 
         Raises:
-            TypeError: A `TypeError` is raised if a required argument is not
-                       found in the `kwargs` dict, or if an unexpected
-                       argument has been given.
+            TypeError:
+                A `TypeError` is raised if a required argument is not found in the `kwargs` dict,
+                or if an unexpected argument has been given.
         """
         init_params = dict()
         fit_params = dict()
@@ -138,7 +140,6 @@ class MLBlock():
         return tunable
 
     def __init__(self, name, **kwargs):
-
         self.name = name
 
         metadata = load_primitive(name)
@@ -174,6 +175,7 @@ class MLBlock():
         self.set_hyperparameters(default)
 
     def __str__(self):
+        """Return a string that represents this block."""
         return 'MLBlock - {}'.format(self.name)
 
     def get_tunable_hyperparameters(self):
@@ -210,9 +212,9 @@ class MLBlock():
         If necessary, a new instance of the primitive is created.
 
         Args:
-            hyperparameters (dict): Dictionary containing as keys the name
-                                    of the hyperparameters and as values
-                                    the values to be used.
+            hyperparameters (dict):
+                Dictionary containing as keys the name of the hyperparameters and as
+                values the values to be used.
         """
         self._hyperparameters.update(hyperparameters)
 
@@ -233,12 +235,13 @@ class MLBlock():
         the primitive is a simple function, this will be a noop.
 
         Args:
-            **kwargs: Any given keyword argument will be directly passed
-                      to the primitive fit method.
+            **kwargs:
+                Any given keyword argument will be directly passed to the primitive fit method.
 
         Raises:
-            TypeError: A `TypeError` might be raised if any argument not
-                       expected by the primitive fit method is given.
+            TypeError:
+                A `TypeError` might be raised if any argument not expected by the primitive fit
+                method is given.
         """
         if self.fit_method is not None:
             fit_args = self._fit_params.copy()

--- a/mlblocks/mlpipeline.py
+++ b/mlblocks/mlpipeline.py
@@ -272,7 +272,7 @@ class MLPipeline():
         else:
             return context
 
-    def fit(self, X=None, y=None, output=None, start_on=None, **kwargs):
+    def fit(self, X=None, y=None, output_=None, start_=None, **kwargs):
         """Fit the blocks of this pipeline.
 
         Sequentially call the `fit` and the `produce` methods of each block,
@@ -288,7 +288,7 @@ class MLPipeline():
             X: Fit Data, which the pipeline will learn from.
             y: Fit Data labels, which the pipeline will use to learn how to
                behave.
-            output (str or int): Output specification, which can be a string or an integer.
+            output_ (str or int): Output specification, which can be a string or an integer.
                 If an integer is given, it is interpreted as the block number, and the whole
                 context after running the specified block will be returned.
                 If a string is given, it is expected to be the name of one block, including
@@ -297,7 +297,7 @@ class MLPipeline():
                 block name and the variable name. If the variable name is given, this will be
                 extracted from the context and returned. Otherwise, the whole context will
                 be returned.
-            start_on (str or int): Block index or block name to start processing from. The
+            start_ (str or int): Block index or block name to start processing from. The
                 value can either be an integer, which will be interpreted as a block index,
                 or the name of a block, including the conter number at the end.
                 If given, the execution of the pipeline will start on the specified block,
@@ -321,16 +321,16 @@ class MLPipeline():
         }
         context.update(kwargs)
 
-        output_block, output_variable = self._get_output_spec(output)
+        output_block, output_variable = self._get_output_spec(output_)
         last_block_name = self._get_block_name(-1)
 
-        if isinstance(start_on, int):
-            start_on = self._get_block_name(start_on)
+        if isinstance(start_, int):
+            start_ = self._get_block_name(start_)
 
         for block_name, block in self.blocks.items():
-            if block_name == start_on:
-                start_on = False
-            elif start_on:
+            if block_name == start_:
+                start_ = False
+            elif start_:
                 LOGGER.debug("Skipping block %s fit", block_name)
                 continue
 
@@ -357,7 +357,7 @@ class MLPipeline():
             if block_name == output_block:
                 return self._get_output(output_variable, context)
 
-    def predict(self, X=None, output='y', start_on=None, **kwargs):
+    def predict(self, X=None, output_='y', start_=None, **kwargs):
         """Produce predictions using the blocks of this pipeline.
 
         Sequentially call the `produce` method of each block, capturing the
@@ -370,7 +370,7 @@ class MLPipeline():
 
         Args:
             X: Data which the pipeline will use to make predictions.
-            output (str or int): Output specification, which can be a string or an integer.
+            output_ (str or int): Output specification, which can be a string or an integer.
                 If an integer is given, it is interpreted as the block number, and the whole
                 context after running the specified block will be returned.
                 If a string is given, it is expected to be the name of one block, including
@@ -379,7 +379,7 @@ class MLPipeline():
                 block name and the variable name. If the variable name is given, this will be
                 extracted from the context and returned. Otherwise, the whole context will
                 be returned.
-            start_on (str or int): Block index or block name to start processing from. The
+            start_ (str or int): Block index or block name to start processing from. The
                 value can either be an integer, which will be interpreted as a block index,
                 or the name of a block, including the conter number at the end.
                 If given, the execution of the pipeline will start on the specified block,
@@ -402,15 +402,15 @@ class MLPipeline():
         }
         context.update(kwargs)
 
-        output_block, output_variable = self._get_output_spec(output)
+        output_block, output_variable = self._get_output_spec(output_)
 
-        if isinstance(start_on, int):
-            start_on = self._get_block_name(start_on)
+        if isinstance(start_, int):
+            start_ = self._get_block_name(start_)
 
         for block_name, block in self.blocks.items():
-            if block_name == start_on:
-                start_on = False
-            elif start_on:
+            if block_name == start_:
+                start_ = False
+            elif start_:
                 LOGGER.debug("Skipping block %s produce", block_name)
                 continue
 
@@ -428,9 +428,9 @@ class MLPipeline():
                 LOGGER.exception("Exception caught producing MLBlock %s", block_name)
                 raise
 
-        if start_on:
+        if start_:
             # We skipped all the blocks up to the end
-            raise ValueError('Unknown block name: {}'.format(start_on))
+            raise ValueError('Unknown block name: {}'.format(start_))
 
     def to_dict(self):
         """Return all the details of this MLPipeline in a dict.

--- a/mlblocks/primitives.py
+++ b/mlblocks/primitives.py
@@ -37,6 +37,7 @@ def add_primitives_path(path):
 
     Raises:
         ValueError: A `ValueError` will be raised if the path is not valid.
+
     """
     if path not in _PRIMITIVES_PATHS:
         if not os.path.isdir(path):
@@ -68,7 +69,6 @@ def get_primitives_paths():
         list:
             The list of folders.
     """
-
     primitives_paths = list()
     entry_points = pkg_resources.iter_entry_points('mlprimitives')
     for entry_point in entry_points:
@@ -99,7 +99,6 @@ def load_primitive(name):
         ValueError: A `ValueError` will be raised if the primitive cannot be
                     found.
     """
-
     for base_path in get_primitives_paths():
         parts = name.split('.')
         number_of_parts = len(parts)

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,9 @@ collect_ignore = ['setup.py']
 
 [tool:pylint]
 good-names = X,y
+
+[doc8]
+max-line-length = 99
+
+[pydocstyle]
+add-ignore = D403,D413,D105,D107

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,13 @@ current_version = 0.3.1-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = release
-values = 
+values =
 	dev
 	release
 
@@ -45,4 +45,3 @@ collect_ignore = ['setup.py']
 
 [tool:pylint]
 good-names = X,y
-

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ development_requires = [
     'graphviz==0.9',
     'ipython==6.5.0',
     'matplotlib==2.2.3',
-    'recommonmark>=0.4.0',
 
     # style check
     'flake8>=3.5.0',

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,10 @@ development_requires = [
     'm2r>=0.2.0',
     'Sphinx>=1.7.1',
     'sphinx_rtd_theme>=0.2.4',
-    'graphviz==0.9',
-    'ipython==6.5.0',
-    'matplotlib==2.2.3',
+    'graphviz>=0.9',
+    'ipython>=6.5.0',
+    'matplotlib>=2.2.3',
+    'autodocsumm>=0.1.10',
 
     # style check
     'flake8>=3.5.0',
@@ -61,8 +62,8 @@ development_requires = [
     'coverage>=4.5.1',
 
     # Documentation style
-    'doc8==0.8.0',
-    'pydocstyle==3.0.0'
+    'doc8>=0.8.0',
+    'pydocstyle>=3.0.0'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ development_requires = [
     # Advanced testing
     'tox>=2.9.1',
     'coverage>=4.5.1',
+
+    # Documentation style
+    'doc8==0.8.0',
+    'pydocstyle==3.0.0'
 ]
 
 

--- a/tests/features/test_partial_outputs.py
+++ b/tests/features/test_partial_outputs.py
@@ -1,0 +1,133 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+import numpy as np
+
+from mlblocks.datasets import load_iris
+from mlblocks.mlpipeline import MLPipeline
+
+
+def almost_equal(obj1, obj2):
+    if isinstance(obj1, dict):
+        if not isinstance(obj2, dict):
+            raise AssertionError("{} is not equal to {}".format(type(obj2), dict))
+
+        for key, value in obj1.items():
+            if key not in obj2:
+                raise AssertionError("{} not in {}".format(key, obj2))
+            almost_equal(value, obj2[key])
+
+    else:
+        np.testing.assert_almost_equal(obj1, obj2)
+
+
+class TestPartialOutputs(TestCase):
+    def setUp(self):
+        dataset = load_iris()
+
+        self.X_train, self.X_test, self.y_train, self.y_test = dataset.get_splits(1)
+
+    def test_fit_output(self):
+
+        # Setup variables
+        primitives = [
+            'sklearn.preprocessing.StandardScaler',
+            'sklearn.linear_model.LogisticRegression'
+        ]
+        pipeline = MLPipeline(primitives)
+
+        int_block = 0
+        invalid_int = 10
+        str_block = 'sklearn.preprocessing.StandardScaler#1'
+        invalid_block = 'InvalidBlockName'
+        str_block_variable = 'sklearn.preprocessing.StandardScaler#1.y'
+        invalid_variable = 'sklearn.preprocessing.StandardScaler#1.invalid'
+
+        # Run
+        int_out = pipeline.fit(self.X_train[0:5], self.y_train[0:5], output_=int_block)
+        str_out = pipeline.fit(self.X_train[0:5], self.y_train[0:5], output_=str_block)
+        str_out_variable = pipeline.fit(self.X_train[0:5], self.y_train[0:5],
+                                        output_=str_block_variable)
+        no_output = pipeline.fit(self.X_train, self.y_train)
+
+        # Assert successful calls
+        X = np.array([
+            [0.71269665, -1.45152899, 0.55344946, 0.31740553],
+            [0.26726124, 1.23648766, -1.1557327, -1.0932857],
+            [-1.95991577, 0.967686, -1.1557327, -1.0932857],
+            [0.71269665, -0.645124, 0.39067021, 0.31740553],
+            [0.26726124, -0.10752067, 1.36734573, 1.55176035]
+        ])
+        y = np.array([1, 0, 0, 1, 2])
+        context = {
+            'X': X,
+            'y': y
+        }
+        almost_equal(context, int_out)
+        almost_equal(context, str_out)
+
+        almost_equal(y, str_out_variable)
+
+        assert no_output is None
+
+        # Run asserting exceptions
+        with self.assertRaises(IndexError):
+            pipeline.fit(self.X_train[0:5], self.y_train[0:5], output_=invalid_int)
+
+        with self.assertRaises(ValueError):
+            pipeline.fit(self.X_train[0:5], self.y_train[0:5], output_=invalid_block)
+
+        with self.assertRaises(ValueError):
+            pipeline.fit(self.X_train[0:5], self.y_train[0:5], output_=invalid_variable)
+
+    def test_fit_start(self):
+        # Setup variables
+        primitives = [
+            'sklearn.preprocessing.StandardScaler',
+            'sklearn.linear_model.LogisticRegression'
+        ]
+        pipeline = MLPipeline(primitives)
+
+        # Mock the first block
+        block_mock = Mock()
+        pipeline.blocks['sklearn.preprocessing.StandardScaler#1'] = block_mock
+
+        # Run first block
+        context = {
+            'X': self.X_train,
+            'y': self.y_train
+        }
+        int_start = 1
+        str_start = 'sklearn.linear_model.LogisticRegression#1'
+
+        pipeline.fit(start_=int_start, **context)
+        pipeline.fit(start_=str_start, **context)
+
+        # Assert that mock has not been called
+        block_mock.fit.assert_not_called()
+
+    def test_predict_start(self):
+        # Setup variables
+        primitives = [
+            'sklearn.preprocessing.StandardScaler',
+            'sklearn.linear_model.LogisticRegression'
+        ]
+        pipeline = MLPipeline(primitives)
+        pipeline.fit(self.X_train, self.y_train)
+
+        # Mock the first block
+        block_mock = Mock()
+        pipeline.blocks['sklearn.preprocessing.StandardScaler#1'] = block_mock
+
+        # Run first block
+        context = {
+            'X': self.X_train,
+        }
+        int_start = 1
+        str_start = 'sklearn.linear_model.LogisticRegression#1'
+
+        pipeline.predict(start_=int_start, **context)
+        pipeline.predict(start_=str_start, **context)
+
+        # Assert that mock has not been called
+        block_mock.predict.assert_not_called()


### PR DESCRIPTION
Resolve #58 and #61 

Allow getting intermediate outputs and allow fitting or producing only half of the pipeline.
Also update the documentation to match the changes from the  latest MLPrimitives versions.

The implementation has been done as follows:
* New optional keyword arguments `output_` and `start_` have been added to `MLPipeline` `fit` and `predict` methods.
* The `output_` argument can be either an `int` or a `str`, and encodes a `block_name` and a `variable_name` within it:
    * If it's an `int`, it is interpreted as the block index, and the method call will return the context right after the indicated block's produce method has been called. As all indices in python, 0 is the first one. Also, negative values work, so -1 is the last block. Indices that are either too big or too small raise an `IndexError`.
    * If it's an `str`, it is expected to be the name of a block, including the counter number at the end: `name.of.the.primitive#n`. In this case, the method call will return the context right after the indicated block's produce method has been called. Optionally, a variable name can be added at the end, using a `'.'` as separator: `name.of.the.primitive#n.variable_name`. In this case, instead of returning all the context, the corresponding variable will be extracted from it. If the block name does not match a block exactly, or if the indicated variable cannot be found in the context, a Value error is raised.
* The `start_` argument can be either an `int` or an `str`, and it is interpreted as either the index or the name of a block. If given, the execution of the pipeline will start on that block, and all the blocks before that will be skipped. If and `int` is given and the index is too big or to small, an `IndexError` will be raised. If an `str` is given and it does not match the name of a block exactly, a `ValueError` will be raised.

As a consequence of this development, several new possibilities arise:

## Issue #58: Getting Intermediate Outputs

Once the pipeline has been fit, we can obtain an intermediate output by specifying the name or the index which we want to get the output from:

```python
primitives = ['first_primitive', 'second_primitive', 'third_primitive']
pipeline = MLPipeline(primitives)
pipeline.fit(X_train, y_train)
output = 1  # alternatively, "second_primitive#1"
context_after_second_primitive = pipeline.produce(X_test, output_=output)
```

If we only need one of the variables, we can get it by specifying the block name and the variable name

```python
output = 'second_primitive#1.X'
X_after_primitive2 = pipeline.produce(X_test, output_=output)
```

Partial predict outputs can also be obtained during the fit process:

```python
output = 'second_primitive#1'
context_after_second_primitive = pipeline.fit(X_train, y_train, output_=output)
```

## Issue #61: Partial re-fit

By using the previous feature, we can capture the status of the context after a certain block, and then use the `start_` argument to fit and produce the rest of the pipeline multiple times:

```python
output = 'second_primitive#1'
context_after_second_primitive = pipeline.fit(X_train, y_train, output_=output)
start = 'third_primitive#1'
pipeline.fit(start_=start, **context_after_second_primitive)
output = pipeline.predict(start_=start, **context_after_second_primitive)
```

And we can even set new hyperparameters between calls:

```python
pipeline.set_hyperparameters({
    'third_primitive': {
        'some_argument': 'some_value'
    }
})
pipeline.fit(start_=start, **context_after_second_primitive)
new_output = pipeline.predict(start_=start, **context_after_second_primitive)
```