### PR TITLE
Issue 90 explore pipelines and primitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test: ## run tests quickly with the default Python
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox
-	tox
+	tox -r
 
 .PHONY: coverage
 coverage: ## check code coverage quickly with the default Python

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 <i>An open source project from Data to AI Lab at MIT.</i>
 </p>
 
-
-
 <p align="left">
 <img width=20% src="https://dai.lids.mit.edu/wp-content/uploads/2018/06/mlblocks-icon.png" alt=“MLBlocks” />
 </p>
@@ -22,7 +20,7 @@ Pipelines and Primitives for Machine Learning and Data Science.
 * Documentation: https://HDI-Project.github.io/MLBlocks
 - Homepage: https://github.com/HDI-Project/MLBlocks
 
-# Overview
+# MLBlocks
 
 MLBlocks is a simple framework for composing end-to-end tunable Machine Learning Pipelines by
 seamlessly combining tools from any python library with a simple, common and uniform interface.

--- a/README.md
+++ b/README.md
@@ -13,19 +13,14 @@
 Pipelines and Primitives for Machine Learning and Data Science.
 </p>
 
-[![PyPi][pypi-img]][pypi-url]
-[![Travis][travis-img]][travis-url]
-[![CodeCov][codecov-img]][codecov-url]
-
-[pypi-img]: https://img.shields.io/pypi/v/mlblocks.svg
-[pypi-url]: https://pypi.python.org/pypi/mlblocks
-[travis-img]: https://travis-ci.org/HDI-Project/MLBlocks.svg?branch=master
-[travis-url]: https://travis-ci.org/HDI-Project/MLBlocks
-[codecov-img]: https://codecov.io/gh/HDI-Project/MLBlocks/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/HDI-Project/MLBlocks
+[![PyPi](https://img.shields.io/pypi/v/mlblocks.svg)](https://pypi.python.org/pypi/mlblocks)
+[![Travis](https://travis-ci.org/HDI-Project/MLBlocks.svg?branch=master)](https://travis-ci.org/HDI-Project/MLBlocks)
+[![CodeCov](https://codecov.io/gh/HDI-Project/MLBlocks/branch/master/graph/badge.svg)](https://codecov.io/gh/HDI-Project/MLBlocks)
+[![Downloads](https://pepy.tech/badge/mlblocks)](https://pepy.tech/project/mlblocks)
 
 * Free software: MIT license
 * Documentation: https://HDI-Project.github.io/MLBlocks
+- Homepage: https://github.com/HDI-Project/MLBlocks
 
 # Overview
 
@@ -44,24 +39,82 @@ Features include:
   outputs per primitive.
 * Easy save and load Pipelines using JSON Annotations.
 
-# Installation
+# Install
 
-The simplest and recommended way to install MLBlocks is using `pip`:
+## Requirements
+
+**MLBlocks** has been developed and tested on [Python 3.5 and 3.6](https://www.python.org/downloads/)
+
+Also, although it is not strictly required, the usage of a
+[virtualenv](https://virtualenv.pypa.io/en/latest/) is highly recommended in order to avoid
+interfering with other software installed in the system where **MLBlocks** is run.
+
+These are the minimum commands needed to create a virtualenv using python3.6 for **MLBlocks**:
+
+```bash
+pip install virtualenv
+virtualenv -p $(which python3.6) mlblocks-venv
+```
+
+Afterwards, you have to execute this command to have the virtualenv activated:
+
+```bash
+source mlblocks-venv/bin/activate
+```
+
+Remember about executing it every time you start a new console to work on **MLBlocks**!
+
+## Install with pip
+
+After creating the virtualenv and activating it, we recommend using
+[pip](https://pip.pypa.io/en/stable/) in order to install **MLBlocks**:
 
 ```bash
 pip install mlblocks
 ```
 
-Alternatively, you can also clone the repository and install it from sources
+This will pull and install the latest stable release from [PyPi](https://pypi.org/).
+
+## Install from source
+
+Alternatively, with your virtualenv activated, you can clone the repository and install it from
+source by running `make install` on the `stable` branch:
 
 ```bash
 git clone git@github.com:HDI-Project/MLBlocks.git
 cd MLBlocks
+git checkout stable
 make install
 ```
 
-For development, you can use `make install-develop` instead in order to install all
-the required dependencies for testing and code linting.
+## Install for Development
+
+If you want to contribute to the project, a few more steps are required to make the project ready
+for development.
+
+First, please head to [the GitHub page of the project](https://github.com/HDI-Project/MLBlocks)
+and make a fork of the project under you own username by clicking on the **fork** button on the
+upper right corner of the page.
+
+Afterwards, clone your fork and create a branch from master with a descriptive name that includes
+the number of the issue that you are going to work on:
+
+```bash
+git clone git@github.com:{your username}/MLBlocks.git
+cd MLBlocks
+git branch issue-xx-cool-new-feature master
+git checkout issue-xx-cool-new-feature
+```
+
+Finally, install the project with the following command, which will install some additional
+dependencies for code linting and testing.
+
+```bash
+make install-develop
+```
+
+Make sure to use them regularly while developing by running the commands `make lint` and `make test`.
+
 
 ## MLPrimitives
 
@@ -75,12 +128,12 @@ with this command:
 pip install mlprimitives
 ```
 
-# Usage Example
+# Quickstart
 
 Below there is a short example about how to use MLBlocks to create a simple pipeline, fit it
 using demo data and use it to make predictions.
 
-Please make sure to having installed [MLPrimitives](https://github.com/HDI-Project/MLPrimitives)
+Please make sure to also having installed [MLPrimitives](https://github.com/HDI-Project/MLPrimitives)
 before following it.
 
 For advance usage and more detailed explanation about each component, please have a look
@@ -153,7 +206,7 @@ its `get_hyperparameters` method:
 }
 ```
 
-### Making predictions
+## Making predictions
 
 Once we have created the pipeline with the desired hyperparameters we can fit it
 and then use it to make predictions on new data.
@@ -180,7 +233,7 @@ to obtain predictions from the pipeline.
 array([3, 2, 1, ..., 1, 1, 2])
 ```
 
-## What's Next?
+# What's Next?
 
 If you want to learn more about how to tune the pipeline hyperparameters, save and load
 the pipelines using JSON annotations or build complex multi-branched pipelines, please

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -24,6 +24,7 @@ them to the `MLPipeline class`_:
 
     from mlblocks import MLPipeline
     primitives = [
+        'mlprimitives.custom.feature_extraction.CategoricalEncoder',
         'mlprimitives.custom.feature_extraction.StringVectorizer',
         'sklearn.ensemble.RandomForestClassifier',
     ]

--- a/mlblocks/discovery.py
+++ b/mlblocks/discovery.py
@@ -312,11 +312,11 @@ def _search_annotations(base_path, pattern, parts=None):
     return annotations
 
 
-def _match_filter(annotation, key, value):
+def _match(annotation, key, value):
     if '.' in key:
         name, key = key.split('.', 1)
         part = annotation.get(name) or dict()
-        return _match_filter(part, key, value)
+        return _match(part, key, value)
 
     annotation_value = annotation.get(key)
     if not isinstance(annotation_value, type(value)):
@@ -338,7 +338,7 @@ def _get_annotations_list(paths, loader, pattern, filters):
     for name in sorted(annotations.values()):
         annotation = loader(name)
         for key, value in filters.items():
-            if not _match_filter(annotation, key, value):
+            if not _match(annotation, key, value):
                 break
 
         else:
@@ -347,11 +347,11 @@ def _get_annotations_list(paths, loader, pattern, filters):
     return matching
 
 
-def get_primitives_list(pattern='', filters=None):
+def find_primitives(pattern='', filters=None):
     filters = filters or dict()
     return _get_annotations_list(get_primitives_paths(), load_primitive, pattern, filters)
 
 
-def get_pipelines_list(pattern='', filters=None):
+def find_pipelines(pattern='', filters=None):
     filters = filters or dict()
     return _get_annotations_list(get_pipelines_paths(), load_pipeline, pattern, filters)

--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -27,6 +27,8 @@ class MLBlock():
     Attributes:
         name (str):
             Name given to this MLBlock.
+        metadata (dict):
+            Additional information about this primitive
         primitive (object):
             the actual function or instance which this MLBlock wraps.
         fit_args (dict):
@@ -143,22 +145,22 @@ class MLBlock():
     def __init__(self, name, **kwargs):
         self.name = name
 
-        metadata = load_primitive(name)
+        primitive = load_primitive(name)
 
-        self.primitive = import_object(metadata['primitive'])
+        self.primitive = import_object(primitive['primitive'])
 
-        self._fit = metadata.get('fit', dict())
+        self._fit = primitive.get('fit', dict())
         self.fit_args = self._fit.get('args', [])
         self.fit_method = self._fit.get('method')
 
-        self._produce = metadata['produce']
+        self._produce = primitive['produce']
         self.produce_args = self._produce['args']
         self.produce_output = self._produce['output']
         self.produce_method = self._produce.get('method')
 
         self._class = bool(self.produce_method)
 
-        hyperparameters = metadata.get('hyperparameters', dict())
+        hyperparameters = primitive.get('hyperparameters', dict())
         init_params, fit_params, produce_params = self._extract_params(kwargs, hyperparameters)
 
         self._hyperparameters = init_params

--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -146,22 +146,22 @@ class MLBlock():
     def __init__(self, name, **kwargs):
         self.name = name
 
-        primitive = load_primitive(name)
+        self.metadata = load_primitive(name)
 
-        self.primitive = import_object(primitive['primitive'])
+        self.primitive = import_object(self.metadata['primitive'])
 
-        self._fit = primitive.get('fit', dict())
+        self._fit = self.metadata.get('fit', dict())
         self.fit_args = self._fit.get('args', [])
         self.fit_method = self._fit.get('method')
 
-        self._produce = primitive['produce']
+        self._produce = self.metadata['produce']
         self.produce_args = self._produce['args']
         self.produce_output = self._produce['output']
         self.produce_method = self._produce.get('method')
 
         self._class = bool(self.produce_method)
 
-        hyperparameters = primitive.get('hyperparameters', dict())
+        hyperparameters = self.metadata.get('hyperparameters', dict())
         init_params, fit_params, produce_params = self._extract_params(kwargs, hyperparameters)
 
         self._hyperparameters = init_params

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
 tests_require = [
     'pytest>=3.4.2',
     'pytest-cov>=2.6.0',
-    'mlprimitives>=0.1.3,<0.2',
+    'mlprimitives>=0.2,<0.3',
     'urllib3>=1.20,<1.25',
     'setuptools>=41.0.0',
     'numpy<1.17',

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 import tempfile
 import uuid
 from unittest.mock import Mock, call, patch
@@ -239,8 +238,7 @@ def test__search_annotations(os_mock):
         False
     ]
 
-    pattern = re.compile('other')
-    annotations = discovery._search_annotations('/path/to', pattern)
+    annotations = discovery._search_annotations('/path/to', 'other')
 
     assert annotations == {
         '/path/to/another.primitive.json': 'another.primitive',
@@ -338,7 +336,7 @@ def test__match_multiple_keys():
 
 
 @patch('mlblocks.discovery._search_annotations')
-def test__get_annotations_list(search_annotations_mock):
+def test__find_annotations(search_annotations_mock):
     search_annotations_mock.return_value = {
         '/path/to/a/classifier.primitive.json': 'classifier.primitive',
         '/path/to/a/regressor.primitive.json': 'regressor.primitive',
@@ -365,29 +363,29 @@ def test__get_annotations_list(search_annotations_mock):
     filters = {
         'classifiers.subtype': 'regressor'
     }
-    annotations = discovery._get_annotations_list(['/a/path'], loader, 'pattern', filters)
+    annotations = discovery._find_annotations(['/a/path'], loader, 'pattern', filters)
 
     assert annotations == ['regressor.primitive']
-    search_annotations_mock.assert_called_once_with('/a/path', re.compile('pattern'))
+    search_annotations_mock.assert_called_once_with('/a/path', 'pattern')
 
 
-@patch('mlblocks.discovery._get_annotations_list')
+@patch('mlblocks.discovery._find_annotations')
 @patch('mlblocks.discovery.get_primitives_paths')
-def test_find_primitives(gpp_mock, gal_mock):
+def test_find_primitives(gpp_mock, fa_mock):
     primitives = discovery.find_primitives('pattern')
 
-    gal_mock.assert_called_once_with(
+    fa_mock.assert_called_once_with(
         gpp_mock.return_value, discovery.load_primitive, 'pattern', dict())
 
-    assert primitives == gal_mock.return_value
+    assert primitives == fa_mock.return_value
 
 
-@patch('mlblocks.discovery._get_annotations_list')
+@patch('mlblocks.discovery._find_annotations')
 @patch('mlblocks.discovery.get_pipelines_paths')
-def test_find_pipelines(gpp_mock, gal_mock):
+def test_find_pipelines(gpp_mock, fa_mock):
     primitives = discovery.find_pipelines('pattern', {'a': 'filter'})
 
-    gal_mock.assert_called_once_with(
+    fa_mock.assert_called_once_with(
         gpp_mock.return_value, discovery.load_pipeline, 'pattern', {'a': 'filter'})
 
-    assert primitives == gal_mock.return_value
+    assert primitives == fa_mock.return_value

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -11,7 +11,7 @@ from pkg_resources import Distribution, EntryPoint
 
 from mlblocks import discovery
 
-FAKE_MLPRIMITIVES_PATH = 'this/is/a/fake'
+FAKE_PRIMITIVES_PATH = 'this/is/a/fake'
 
 
 def test__add_lookup_path_do_nothing():
@@ -78,7 +78,7 @@ def test__load_entry_points_entry_points(iep_mock):
     primitives_ep = EntryPoint(
         'primitives',
         'tests.test_discovery',
-        attrs=['FAKE_MLPRIMITIVES_PATH'],
+        attrs=['FAKE_PRIMITIVES_PATH'],
         dist=Distribution()
     )
     iep_mock.return_value = [

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -384,7 +384,7 @@ def test_find_primitives(gpp_mock, gal_mock):
 
 @patch('mlblocks.discovery._get_annotations_list')
 @patch('mlblocks.discovery.get_pipelines_paths')
-def test_find_primitives(gpp_mock, gal_mock):
+def test_find_pipelines(gpp_mock, gal_mock):
     primitives = discovery.find_pipelines('pattern', {'a': 'filter'})
 
     gal_mock.assert_called_once_with(


### PR DESCRIPTION
Resolve #90 
Resolve #22 

Add functions to explore primitives and pipelines by name and custom filters.

```
In [1]: from mlblocks.discovery import find_primitives, find_pipelines                                                                

In [2]: filters = { 
   ...:     'classifiers.type': 'preprocessor', 
   ...:     'classifiers.subtype': 'feature_extractor', 
   ...:     'modalities': 'image' 
   ...: }                                                                                                                             

In [3]: find_primitives(filters=filters)                                                                                              
Out[3]: 
['keras.applications.densenet.DenseNet121',
 'keras.applications.densenet.DenseNet169',
 'keras.applications.densenet.DenseNet201',
 'keras.applications.inception_v3.InceptionV3',
 'keras.applications.mobilenet.MobileNet',
 'keras.applications.resnet50.ResNet50',
 'keras.applications.xception.Xception',
 'skimage.feature.hog']

In [4]: find_pipelines(filters={'metadata.data_type': 'image'})                                                                       
Out[4]: 
['image.classification.hog.rf',
 'image.classification.hog.xgb',
 'image.classification.resnet50.xgb',
 'image.regression.hog.rf',
 'image.regression.hog.xgb',
 'image.regression.resnet50.xgb',
 'keras.Sequential.SingleLayerCNNImageClassifier',
 'keras.Sequential.SingleLayerCNNImageRegressor',
 'keras.Sequential.VGGCNNClassifier']
```