### PR TITLE
Allow passing fit and produce args as init params

### DIFF
--- a/mlblocks/mlpipeline.py
+++ b/mlblocks/mlpipeline.py
@@ -87,16 +87,21 @@ class MLPipeline():
 
         block_names_count = Counter()
         for primitive in self.primitives:
+            if isinstance(primitive, str):
+                primitive_name = primitive
+            else:
+                primitive_name = primitive['name']
+
             try:
-                block_names_count.update([primitive])
-                block_count = block_names_count[primitive]
-                block_name = '{}#{}'.format(primitive, block_count)
+                block_names_count.update([primitive_name])
+                block_count = block_names_count[primitive_name]
+                block_name = '{}#{}'.format(primitive_name, block_count)
                 block_params = self.init_params.get(block_name, dict())
                 if not block_params:
-                    block_params = self.init_params.get(primitive, dict())
+                    block_params = self.init_params.get(primitive_name, dict())
                     if block_params and block_count > 1:
                         LOGGER.warning(("Non-numbered init_params are being used "
-                                        "for more than one block %s."), primitive)
+                                        "for more than one block %s."), primitive_name)
 
                 block = MLBlock(primitive, **block_params)
                 blocks[block_name] = block
@@ -330,10 +335,6 @@ class MLPipeline():
 
             if variable in context:
                 kwargs[name] = context[variable]
-            elif 'default' in arg:
-                kwargs[name] = arg['default']
-            elif arg.get('required', True):
-                raise ValueError('Input variable {} not found in context'.format(variable))
 
         return kwargs
 
@@ -517,11 +518,12 @@ class MLPipeline():
                   the value of that variable from the context will extracted and returned
                   after the produce method of that block has been called.
         """
-        context = {
-            'X': X,
-            'y': y
-        }
-        context.update(kwargs)
+        context = kwargs.copy()
+        if X is not None:
+            context['X'] = X
+
+        if y is not None:
+            context['y'] = y
 
         output_block, output_variable = self._get_output_spec(output_)
         last_block_name = self._get_block_name(-1)
@@ -624,10 +626,9 @@ class MLPipeline():
                   the value of that variable from the context will extracted and returned
                   after the produce method of that block has been called.
         """
-        context = {
-            'X': X
-        }
-        context.update(kwargs)
+        context = kwargs.copy()
+        if X is not None:
+            context['X'] = X
 
         output_block, output_variable = self._get_output_spec(output_)
 

--- a/tests/features/test_fit_predicr_args.py
+++ b/tests/features/test_fit_predicr_args.py
@@ -1,0 +1,42 @@
+from mlblocks.mlpipeline import MLPipeline
+
+
+def test_fit_predict_args_in_init():
+
+    def add(a, b):
+        return a + b
+
+    primitive = {
+        'name': 'add',
+        'primitive': add,
+        'produce': {
+            'args': [
+                {
+                    'name': 'a',
+                    'type': 'float',
+                },
+                {
+                    'name': 'b',
+                    'type': 'float',
+                },
+            ],
+            'output': [
+                {
+                    'type': 'float',
+                    'name': 'out'
+                }
+            ]
+        }
+    }
+
+    primitives = [primitive]
+    init_params = {
+        'add': {
+            'b': 10
+        }
+    }
+    pipeline = MLPipeline(primitives, init_params=init_params)
+
+    out = pipeline.predict(a=3)
+
+    assert out == 13

--- a/tests/test_mlblock.py
+++ b/tests/test_mlblock.py
@@ -323,6 +323,7 @@ class TestMLBlock(TestCase):
     @patch('mlblocks.mlblock.load_primitive')
     def test___init__(self, load_primitive_mock, import_object_mock, set_hps_mock):
         load_primitive_mock.return_value = {
+            'name': 'a_primitive_name',
             'primitive': 'a_primitive_name',
             'produce': {
                 'args': [
@@ -335,9 +336,22 @@ class TestMLBlock(TestCase):
             }
         }
 
-        mlblock = MLBlock('given_primitive_name', argument='value')
+        mlblock = MLBlock('a_primitive_name', argument='value')
 
-        assert mlblock.name == 'given_primitive_name'
+        assert mlblock.metadata == {
+            'name': 'a_primitive_name',
+            'primitive': 'a_primitive_name',
+            'produce': {
+                'args': [
+                    {
+                        'name': 'argument'
+                    }
+                ],
+                'output': [
+                ]
+            }
+        }
+        assert mlblock.name == 'a_primitive_name'
         assert mlblock.primitive == import_object_mock.return_value
         assert mlblock._fit == dict()
         assert mlblock.fit_args == list()
@@ -370,6 +384,7 @@ class TestMLBlock(TestCase):
     @patch('mlblocks.mlblock.load_primitive')
     def test___str__(self, load_primitive_mock, import_object_mock):
         load_primitive_mock.return_value = {
+            'name': 'a_primitive_name',
             'primitive': 'a_primitive_name',
             'produce': {
                 'args': [],
@@ -377,15 +392,16 @@ class TestMLBlock(TestCase):
             }
         }
 
-        mlblock = MLBlock('given_primitive_name')
+        mlblock = MLBlock('a_primitive_name')
 
-        assert str(mlblock) == 'MLBlock - given_primitive_name'
+        assert str(mlblock) == 'MLBlock - a_primitive_name'
 
     @patch('mlblocks.mlblock.import_object')
     @patch('mlblocks.mlblock.load_primitive')
     def test_get_tunable_hyperparameters(self, load_primitive_mock, import_object_mock):
         """get_tunable_hyperparameters has to return a copy of the _tunables attribute."""
         load_primitive_mock.return_value = {
+            'name': 'a_primitive_name',
             'primitive': 'a_primitive_name',
             'produce': {
                 'args': [],
@@ -433,6 +449,7 @@ class TestMLBlock(TestCase):
         io_mock.return_value = primitive
 
         lp_mock.return_value = {
+            'name': 'a_primitive',
             'primitive': 'a_primitive',
             'produce': {
                 'args': [],

--- a/tests/test_mlpipeline.py
+++ b/tests/test_mlpipeline.py
@@ -270,7 +270,6 @@ class TestMLPipline(TestCase):
 
         expected = {
             'arg_1': 'arg_1_value',
-            'arg_2': 'arg_2_value',
             'arg_3': 'arg_3_value',
         }
         assert args == expected


### PR DESCRIPTION
Resolve #96 

Allow passing fit and predict arguments that will not change throughout the pipeline lifetime as init_params.

Also, in order to support and properly test this:
* allow passing the primitive annotation dictionary directly to the MLPipeline instead of the primitive name
* allow passing the primitive function (or class) directly within the annotation instead of passing the name to be imported.